### PR TITLE
Implement executable shortcuts for launching the app on non-Windows OS

### DIFF
--- a/ship_editor.command
+++ b/ship_editor.command
@@ -1,0 +1,3 @@
+DIRNAME=`dirname "$0"`
+cd "$DIRNAME"
+jre/bin/java -jar ship_editor.jar

--- a/ship_editor.sh
+++ b/ship_editor.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+DIRNAME=`dirname "$0"`
+cd "$DIRNAME"
+jre/bin/java -jar ./ship_editor.jar


### PR DESCRIPTION
Added pre-made files for launching the app with the java version under the jre of the base folder under macOS (tested and verified) and Linux (untested but _should_ work).

These files would simply need to be included in future releases.